### PR TITLE
Make hostname canonicalization optional

### DIFF
--- a/spnego.go
+++ b/spnego.go
@@ -8,7 +8,7 @@ import (
 
 // Provider is the interface that wraps OS agnostic functions for handling SPNEGO communication
 type Provider interface {
-	SetSPNEGOHeader(*http.Request) error
+	SetSPNEGOHeader(*http.Request, bool) error
 }
 
 func canonicalizeHostname(hostname string) (string, error) {

--- a/spnego_gokrb5.go
+++ b/spnego_gokrb5.go
@@ -65,10 +65,13 @@ func (k *krb5) makeClient() error {
 	return err
 }
 
-func (k *krb5) SetSPNEGOHeader(req *http.Request) error {
-	h, err := canonicalizeHostname(req.URL.Hostname())
-	if err != nil {
-		return err
+func (k *krb5) SetSPNEGOHeader(req *http.Request, canonicalize bool) error {
+	h := req.URL.Hostname()
+	if canonicalize {
+		var err error
+		if h, err = canonicalizeHostname(h); err != nil {
+			return err
+		}
 	}
 
 	if err := k.makeCfg(); err != nil {

--- a/spnego_windows.go
+++ b/spnego_windows.go
@@ -16,10 +16,13 @@ func New() Provider {
 }
 
 // SetSPNEGOHeader puts the SPNEGO authorization header on HTTP request object
-func (s *sspi) SetSPNEGOHeader(req *http.Request) error {
-	h, err := canonicalizeHostname(req.URL.Hostname())
-	if err != nil {
-		return err
+func (s *sspi) SetSPNEGOHeader(req *http.Request, canonicalize bool) error {
+	h := req.URL.Hostname()
+	if canonicalize {
+		var err error
+		if h, err = canonicalizeHostname(h); err != nil {
+			return err
+		}
 	}
 	spn := "HTTP/" + h
 

--- a/transport.go
+++ b/transport.go
@@ -5,7 +5,8 @@ import "net/http"
 // Transport extends the native http.Transport to provide SPNEGO communication
 type Transport struct {
 	http.Transport
-	spnego Provider
+	spnego         Provider
+	NoCanonicalize bool
 }
 
 // Error is used to distinguish errors from underlying libraries (gokrb5 or sspi).
@@ -24,7 +25,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		t.spnego = New()
 	}
 
-	if err := t.spnego.SetSPNEGOHeader(req); err != nil {
+	if err := t.spnego.SetSPNEGOHeader(req, !t.NoCanonicalize); err != nil {
 		return nil, &Error{Err: err}
 	}
 


### PR DESCRIPTION
I have a use-case where the reverse DNS records aren't correct (and aren't under my control). Hostname canonicalization breaks this, so I'd like to be able to skip it.

I've added a field to the API which will default to the current behaviour, but allow you to opt-in to not canonicalizing the hostname.